### PR TITLE
Fix for CVE-2023-2976

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>31.0.1-android</version>
+      <version>32.0.1-android</version>
     </dependency>
     <dependency>
       <groupId>org.cyclopsgroup</groupId>


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2023-2976 for details: _Even though the security vulnerability is fixed in version 32.0.0, we recommend using version 32.0.1 as version 32.0.0 breaks some functionality under Windows._